### PR TITLE
Issue#2: Implement API route for Covid Observations with confirmed

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,0 +1,31 @@
+class TopController < ApplicationController
+  before_action :set_covid_observation, only: :confirmed
+
+  def confirmed
+    render json: {
+      observation_date: @observation_date || nil,
+      countries: jsonified_covid_observations
+    }
+  end
+
+  private
+
+  def set_covid_observation
+    @covid_observations = CovidObservation.where('confirmed >= ?', 1)
+
+    if has_valid_date?
+      @covid_observations =
+        @covid_observations.where(observation_date: @observation_date)
+    end
+  end
+
+  def jsonified_covid_observations
+    @covid_observations
+      .limit(params[:max_results] || 10)
+      .as_json(only: [:country, :confirmed, :deaths, :recovered])
+  end
+
+  def has_valid_date?
+    @observation_date = Date.parse(params[:observation_date]) rescue nil
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  get 'top/confirmed'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
* implement TopController that would handle every route that would be called
under the /top route.

Process:
1. before entering the /top/confirmed route, call the set_covid_observation
method to set our initial collection of CovidObservations with confirmed cases.

If the route given has a valid observation_date, then filter the
CovidObservations collection further by that observation_date

2. upon entering the /top/confirmed route, the confirmed method would be called,
this would call the jsonified_covid_observations method to give out only the
necessary data.

This method will also shape the data that would be sent.

Fixes #2